### PR TITLE
Throw out first location provider location update

### DIFF
--- a/Assets/Mapbox/Unity/Ar/SimpleAutomaticSynchronizationContextBehaviour.cs
+++ b/Assets/Mapbox/Unity/Ar/SimpleAutomaticSynchronizationContextBehaviour.cs
@@ -111,17 +111,25 @@ namespace Mapbox.Unity.Ar
 		void LocationProvider_OnLocationUpdated(Location location)
 		{
 			if (location.IsLocationUpdated)
-			{
-				var latitudeLongitude = location.LatitudeLongitude;
-				Unity.Utilities.Console.Instance.Log(string.Format("Location: {0},{1}\tAccuracy: {2}\tHeading: {3}",
+			{      
+			        if (location.Accuracy < 4.5) //With this line, we can control accuracy of Gps updates. 
+				{
+				   var latitudeLongitude = location.LatitudeLongitude;
+				   Unity.Utilities.Console.Instance.Log(string.Format("Location: {0},{1}\tAccuracy: {2}\tHeading: {3}",
 																   latitudeLongitude.x, latitudeLongitude.y, location.Accuracy, location.Heading), "lightblue");
 
-				var position = Conversions.GeoToWorldPosition(latitudeLongitude,
-															 	_map.CenterMercator,
-															 	_map.WorldRelativeScale).ToVector3xz();
+				  var position = Conversions.GeoToWorldPosition(latitudeLongitude,_map.CenterMercator,_map.WorldRelativeScale).ToVector3xz();
 
-				_synchronizationContext.AddSynchronizationNodes(location, position, _arPositionReference.localPosition);
+				  _synchronizationContext.AddSynchronizationNodes(location, position, _arPositionReference.localPosition);
+				
+				}else 
+			        {
+			           Unity.Utilities.Console.Instance.Log("Gps update ignored due to bad accuracy","red");
+			        }
+			
+				
 			}
+			
 		}
 
 		void SynchronizationContext_OnAlignmentAvailable(Ar.Alignment alignment)


### PR DESCRIPTION
Throwing out  first location provider location update really improves first aligment. Besides that, we can control gps updates' accuracy by ignoring gps updates up to the accuracy value that we want. It could make user walk or wait more for more accurate gps updates but it is better than aligment with bad accuracy gps updates.